### PR TITLE
Update json4s to 3.5.2-ccap

### DIFF
--- a/modules/swagger-annotations/pom.xml
+++ b/modules/swagger-annotations/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.wordnik</groupId>
   <artifactId>swagger-annotations</artifactId>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <packaging>bundle</packaging>
   <name>swagger-annotations</name>
 

--- a/modules/swagger-core/pom.xml
+++ b/modules/swagger-core/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -10,7 +10,7 @@
   <artifactId>swagger-core_2.12</artifactId>
   <packaging>bundle</packaging>
   <name>swagger-core</name>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <defaultGoal>install</defaultGoal>
@@ -102,13 +102,13 @@
       <artifactId>json4s-ext_2.12</artifactId>
       <version>${json4s-version}</version>
       <scope>compile</scope>
-    </dependency> 
+    </dependency>
     <dependency>
       <groupId>org.json4s</groupId>
       <artifactId>json4s-native_2.12</artifactId>
       <version>${json4s-version}</version>
       <scope>compile</scope>
-    </dependency>    
+    </dependency>
     <dependency>
       <groupId>org.json4s</groupId>
       <artifactId>json4s-jackson_2.12</artifactId>

--- a/modules/swagger-core/pom.xml
+++ b/modules/swagger-core/pom.xml
@@ -11,6 +11,18 @@
   <packaging>bundle</packaging>
   <name>swagger-core</name>
   <version>1.3.12-ccap03</version>
+  <repositories>
+    <repository>
+      <id>ccap-maven</id>
+      <name>CCAP Maven</name>
+      <url>https://repoman.wicourts.gov/artifactory/scala</url>
+    </repository>
+    <repository>
+      <id>maven</id>
+      <name>Apache Maven</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
+  </repositories>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <defaultGoal>install</defaultGoal>

--- a/modules/swagger-jaxrs-utils/pom.xml
+++ b/modules/swagger-jaxrs-utils/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.wordnik</groupId>
   <artifactId>swagger-jaxrs-utils_2.12</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <name>swagger-jaxrs-utils</name>
   <build>
     <defaultGoal>install</defaultGoal>

--- a/modules/swagger-jaxrs/pom.xml
+++ b/modules/swagger-jaxrs/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.wordnik</groupId>
   <artifactId>swagger-jaxrs_2.12</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <name>swagger-jaxrs</name>
   <build>
     <defaultGoal>install</defaultGoal>

--- a/modules/swagger-jersey-jaxrs/pom.xml
+++ b/modules/swagger-jersey-jaxrs/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.wordnik</groupId>
   <artifactId>swagger-jersey-jaxrs_2.12</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <name>swagger-jersey-jaxrs</name>
   <build>
     <defaultGoal>install</defaultGoal>

--- a/modules/swagger-jersey2-jaxrs/pom.xml
+++ b/modules/swagger-jersey2-jaxrs/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.wordnik</groupId>
   <artifactId>swagger-jersey2-jaxrs_2.12</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <name>swagger-jersey2-jaxrs (Jersey 2.x support)</name>
   <build>
     <defaultGoal>install</defaultGoal>

--- a/modules/swagger-mule/pom.xml
+++ b/modules/swagger-mule/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -10,7 +10,7 @@
   <artifactId>swagger-mule_2.12</artifactId>
   <packaging>jar</packaging>
   <name>swagger-mule</name>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <build>
     <sourceDirectory>src/main/scala</sourceDirectory>
     <plugins>

--- a/modules/swagger-oauth2-auth-server/pom.xml
+++ b/modules/swagger-oauth2-auth-server/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.wordnik</groupId>
   <artifactId>swagger-oauth2-server_2.12</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <name>swagger-oauth2-server</name>
   <build>
     <defaultGoal>install</defaultGoal>

--- a/modules/swagger-servlet/pom.xml
+++ b/modules/swagger-servlet/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.wordnik</groupId>
   <artifactId>swagger-servlet_2.12</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <name>swagger-servlet</name>
   <build>
     <defaultGoal>install</defaultGoal>

--- a/modules/swagger-utils/pom.xml
+++ b/modules/swagger-utils/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -10,7 +10,7 @@
   <artifactId>swagger-utils_2.12</artifactId>
   <packaging>jar</packaging>
   <name>swagger-utils</name>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <defaultGoal>install</defaultGoal>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,18 @@
     <system>github</system>
     <url>https://github.com/swagger-api/swagger-core/issues</url>
   </issueManagement>
+  <repositories>
+    <repository>
+      <id>ccap-maven</id>
+      <name>CCAP Maven</name>
+      <url>https://repoman.wicourts.gov/artifactory/scala</url>
+    </repository>
+    <repository>
+      <id>maven</id>
+      <name>Apache Maven</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
+  </repositories>
   <distributionManagement>
     <repository>
       <id>ccap</id>
@@ -499,7 +511,7 @@
     <jackson-other-version>2.9.10</jackson-other-version>
     <jackson-scala-version>2.9.10</jackson-scala-version>
     <logback-version>1.0.1</logback-version>
-    <json4s-version>4.1.0-M7</json4s-version>
+    <json4s-version>3.5.2-ccap</json4s-version>
     <swagger-ui-version>2.0.24</swagger-ui-version>
 
     <junit-version>4.8.1</junit-version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>swagger-project_2.12</artifactId>
   <packaging>pom</packaging>
   <name>wordnik-swagger-project</name>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <url>https://github.com/swagger-api/swagger-core</url>
   <scm>
     <connection>scm:git:git@github.com:swagger-api/swagger-core.git</connection>
@@ -499,7 +499,7 @@
     <jackson-other-version>2.9.10</jackson-other-version>
     <jackson-scala-version>2.9.10</jackson-scala-version>
     <logback-version>1.0.1</logback-version>
-    <json4s-version>3.5.2</json4s-version>
+    <json4s-version>4.1.0-M7</json4s-version>
     <swagger-ui-version>2.0.24</swagger-ui-version>
 
     <junit-version>4.8.1</junit-version>

--- a/samples/java-dropwizard/pom.xml
+++ b/samples/java-dropwizard/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -10,7 +10,7 @@
   <artifactId>swagger-java-dropwizard-sample-app_2.12</artifactId>
   <packaging>jar</packaging>
   <name>swagger-java-dropwizard-app</name>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <plugins>

--- a/samples/java-jaxrs-cxf/pom.xml
+++ b/samples/java-jaxrs-cxf/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -11,7 +11,7 @@
   <artifactId>swagger-java-cxf-sample_2.12</artifactId>
   <packaging>war</packaging>
   <name>swagger-java-cxf-sample</name>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
 
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/java-jaxrs-no-annotations/pom.xml
+++ b/samples/java-jaxrs-no-annotations/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -10,7 +10,7 @@
   <artifactId>swagger-java-sample-app_2.12</artifactId>
   <packaging>war</packaging>
   <name>swagger-java-jaxrs-app</name>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <plugins>

--- a/samples/java-jaxrs-subresource/pom.xml
+++ b/samples/java-jaxrs-subresource/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>swagger-java-subresource-sample_2.12</artifactId>
   <packaging>war</packaging>
   <name>swagger-java-subresource-sample</name>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <plugins>

--- a/samples/java-jaxrs-wink/pom.xml
+++ b/samples/java-jaxrs-wink/pom.xml
@@ -2,13 +2,13 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.wordnik</groupId>
   <artifactId>swagger-jaxrs-wink-sample_2.12</artifactId>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <packaging>war</packaging>
   <name>swagger-jaxrs-wink-sample_2.12</name>
   <developers>

--- a/samples/java-jaxrs/pom.xml
+++ b/samples/java-jaxrs/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -10,7 +10,7 @@
   <artifactId>swagger-java-sample-app_2.12</artifactId>
   <packaging>war</packaging>
   <name>swagger-java-jaxrs-app</name>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <plugins>

--- a/samples/java-jersey-spring/pom.xml
+++ b/samples/java-jersey-spring/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -10,7 +10,7 @@
   <artifactId>swagger-java-jersey-spring-app_2.12</artifactId>
   <packaging>war</packaging>
   <name>swagger-java-jersey-spring-app</name>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <plugins>

--- a/samples/java-jersey2-guice/pom.xml
+++ b/samples/java-jersey2-guice/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -10,7 +10,7 @@
   <artifactId>swagger-jersey2-guice-sample-app_2.12</artifactId>
   <packaging>war</packaging>
   <name>swagger-jersey2-guice-jaxrs-app</name>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <plugins>
@@ -118,7 +118,7 @@
       <groupId>com.wordnik</groupId>
       <artifactId>swagger-jersey2-jaxrs_2.12</artifactId>
       <scope>compile</scope>
-      <version>1.3.12-ccap02</version>
+      <version>1.3.12-ccap03</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/samples/java-jersey2/pom.xml
+++ b/samples/java-jersey2/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -10,7 +10,7 @@
   <artifactId>swagger-jersey2-sample-app_2.12</artifactId>
   <packaging>war</packaging>
   <name>swagger-jersey2-jaxrs-app</name>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <plugins>
@@ -118,7 +118,7 @@
       <groupId>com.wordnik</groupId>
       <artifactId>swagger-jersey2-jaxrs_2.12</artifactId>
       <scope>compile</scope>
-      <version>1.3.12-ccap02</version>
+      <version>1.3.12-ccap03</version>
         <exclusions>
           <exclusion>
             <groupId>javax.ws.rs</groupId>

--- a/samples/java-mule/pom.xml
+++ b/samples/java-mule/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -10,7 +10,7 @@
   <artifactId>swagger-java-mule-app_2.12</artifactId>
   <packaging>mule</packaging>
   <name>swagger-java-mule-app</name>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <pluginManagement>
@@ -109,7 +109,7 @@
     <dependency>
       <groupId>com.wordnik</groupId>
       <artifactId>swagger-mule_2.12</artifactId>
-      <version>1.3.12-ccap02</version>
+      <version>1.3.12-ccap03</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/samples/java-resteasy-spring/pom.xml
+++ b/samples/java-resteasy-spring/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -10,7 +10,7 @@
   <artifactId>swagger-java-resteasy-spring-sample_2.12</artifactId>
   <packaging>war</packaging>
   <name>swagger-java-resteasy-spring-sample</name>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <plugins>

--- a/samples/java-resteasy/pom.xml
+++ b/samples/java-resteasy/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -10,7 +10,7 @@
   <artifactId>swagger-java-resteasy-sample_2.12</artifactId>
   <packaging>war</packaging>
   <name>swagger-java-resteasy-sample</name>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <plugins>

--- a/samples/no-server/pom.xml
+++ b/samples/no-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/samples/scala-jaxrs-apm/pom.xml
+++ b/samples/scala-jaxrs-apm/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -10,7 +10,7 @@
   <artifactId>swagger-scala-apm-sample-app_2.12</artifactId>
   <packaging>war</packaging>
   <name>swagger-scala-sample-apm-app</name>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <build>
     <plugins>
       <plugin>

--- a/samples/scala-jaxrs-fileupload/pom.xml
+++ b/samples/scala-jaxrs-fileupload/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -10,7 +10,7 @@
   <artifactId>swagger-scala-sample-file-upload-app_2.12</artifactId>
   <packaging>war</packaging>
   <name>swagger-scala-sample-file-upload-app</name>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <build>
     <plugins>
       <plugin>

--- a/samples/scala-jaxrs/pom.xml
+++ b/samples/scala-jaxrs/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -10,7 +10,7 @@
   <artifactId>swagger-scala-sample_2.12</artifactId>
   <packaging>war</packaging>
   <name>swagger-scala-sample-app</name>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <build>
     <plugins>
       <plugin>

--- a/samples/scala-oauth-authorization-server/pom.xml
+++ b/samples/scala-oauth-authorization-server/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -10,7 +10,7 @@
   <artifactId>swagger-oauth-authorization_2.12</artifactId>
   <packaging>war</packaging>
   <name>swagger-oauth-authorization-server</name>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <build>
     <plugins>
       <plugin>

--- a/samples/scala-servlet/pom.xml
+++ b/samples/scala-servlet/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>com.wordnik</groupId>
     <artifactId>swagger-project_2.12</artifactId>
-    <version>1.3.12-ccap02</version>
+    <version>1.3.12-ccap03</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -10,7 +10,7 @@
   <artifactId>swagger-scala-servlet_2.12</artifactId>
   <packaging>war</packaging>
   <name>swagger-scala-servlet-server</name>
-  <version>1.3.12-ccap02</version>
+  <version>1.3.12-ccap03</version>
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
In order to avoid a transitive dependency on scala-xml < 2.1.0
https://github.com/json4s/json4s/commit/bf50cd46247c9dc7bdd910d2d9d699573c7be950